### PR TITLE
Feature/0.0.2.6

### DIFF
--- a/SWSDK.php
+++ b/SWSDK.php
@@ -5,6 +5,7 @@
     require_once dirname(__FILE__) . '/SWServices/Authentication/AuthRequest.php';
     require_once dirname(__FILE__) . '/SWServices/Stamp/StampRequest.php';
     require_once dirname(__FILE__) . '/SWServices/Stamp/StampService.php';
+    require_once dirname(__FILE__) . '/SWServices/Stamp/StampServiceCached.php';
     require_once dirname(__FILE__) . '/SWServices/Issuer/IssuerService.php';
     require_once dirname(__FILE__) . '/SWServices/Cancelation/CancelationService.php';
     require_once dirname(__FILE__) . '/SWServices/Cancelation/CancelationRequest.php';

--- a/SWServices/Services.php
+++ b/SWServices/Services.php
@@ -35,7 +35,7 @@ use Exception;
                 self::$_token = $params['token'];
                 date_default_timezone_set("America/Mexico_City");
                 self::$_expirationDate = new \DateTime('NOW');
-                self::$_expirationDate->add(new \DateInterval("PT5Y"));
+                self::$_expirationDate->add(new \DateInterval("P5Y"));
             }
         }
         

--- a/SWServices/Stamp/StampService.php
+++ b/SWServices/Stamp/StampService.php
@@ -1,15 +1,19 @@
 <?php
 namespace SWServices\Stamp;
-
 use SWServices\Services as Services;
+use SWServices\Stamp\StampServiceCached as stampServiceCached;
 use SWServices\Stamp\StampRequest as stampRequest;
-
 class StampService extends Services {
     public function __construct($params) {
         parent::__construct($params);
     }
 
     public static function Set($params){
+        if(isset($params["cached"])){
+            if($params["cached"])
+                return new stampServiceCached($params);
+            return new StampService($params);
+        }
         return new StampService($params);
     }
     public static function StampV1($xml, $isb64 = false){

--- a/SWServices/Stamp/StampServiceCached.php
+++ b/SWServices/Stamp/StampServiceCached.php
@@ -1,0 +1,164 @@
+<?php
+use Exception as Exception;
+namespace SWServices\Stamp;
+
+use SWServices\Services as Services;
+use SWServices\Stamp\StampRequest as stampRequest;
+
+class StampServiceCached extends Services {
+    public function __construct($params) {
+        parent::__construct($params);
+    }
+
+    public static function Set($params){
+        return new StampServiceCached($params);
+    }
+    public static function StampV1($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+     public static function StampV2($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+     public static function StampV3($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+     public static function StampV4($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+
+    public static function StampVersion2V1($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+    public static function StampVersion2V2($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+    public static function StampVersion2V3($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+    public static function StampVersion2V4($xml, $isb64 = false, $ttl = 600){
+        try{
+            $sello = self::getSignXml($xml);
+            if(apc_exists($sello)){
+                return self::showError($ttl, apc_fetch($sello));
+            }
+            else{
+                apc_store($sello, sha1($xml), $ttl);
+                $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
+                return $response;
+            }
+        }
+        catch(Exeption $ex){
+            throw new Exception("Exception: ".$ex->getMessage());
+        }
+    }
+
+    private static function getSignXml($xml){
+        $xmlA = simplexml_load_string($xml);
+        $json = json_encode($xmlA);
+        $xmlA = json_decode($json, TRUE);
+        return $xmlA["@attributes"]["Sello"];
+    }
+
+    private static function showError($ttl, $hash){
+        $error = array(
+            "message" => "Se evito un duplicado de la factura. Verifique si la misma ya fue timbrada por alguien más.",
+            "messageDetail" => "Factura registrada en la caché hace menos de $ttl segundos por otro proceso, hash(sha1) del xml: $hash",
+            "data" => null,
+            "status" => "error"
+        );
+        return json_decode(json_encode($error));
+    }
+}
+
+?>

--- a/SWServices/Stamp/StampServiceCached.php
+++ b/SWServices/Stamp/StampServiceCached.php
@@ -15,14 +15,13 @@ class StampServiceCached extends Services {
     }
     public static function StampV1($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -31,14 +30,13 @@ class StampServiceCached extends Services {
     }
      public static function StampV2($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -47,14 +45,13 @@ class StampServiceCached extends Services {
     }
      public static function StampV3($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -63,14 +60,13 @@ class StampServiceCached extends Services {
     }
      public static function StampV4($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4", $isb64, Services::get_proxy(), '/cfdi33/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -80,14 +76,13 @@ class StampServiceCached extends Services {
 
     public static function StampVersion2V1($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -96,14 +91,13 @@ class StampServiceCached extends Services {
     }
     public static function StampVersion2V2($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -112,14 +106,13 @@ class StampServiceCached extends Services {
     }
     public static function StampVersion2V3($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){
@@ -128,14 +121,13 @@ class StampServiceCached extends Services {
     }
     public static function StampVersion2V4($xml, $isb64 = false, $ttl = 600){
         try{
-            $sello = self::getSignXml($xml);
-            if(apc_exists($sello)){
-                return self::showError($ttl, apc_fetch($sello));
-            }
-            else{
-                apc_store($sello, sha1($xml), $ttl);
+            $sello = sha1(self::getSignXml($xml));
+            if(apc_add($sello, sha1($xml), $ttl)){
                 $response = stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4", $isb64, Services::get_proxy(), '/cfdi33/v2/stamp/');
                 return $response;
+            }
+            else{
+                return self::showError($ttl, apc_fetch($sello));
             }
         }
         catch(Exeption $ex){


### PR DESCRIPTION
**New**: Clase para timbrado "cached" usando la librería APCU en el servidor del cliente. Para los clientes que no lo usan no afecta, ya que el objecto "cached" se activa a través del constructor de la clase Stamp

**Fix**: date interval añadido en la clase "Services" para token infinito.
