### PR TITLE
Agregar TimeOut a StampServices

### DIFF
--- a/SWServices/Services.php
+++ b/SWServices/Services.php
@@ -11,6 +11,7 @@ use Exception;
         private static $_expirationDate = null;
         private static $_proxy = null;
         private static $_timeSession = "PT2H";
+        private static $_timeOut = 60;
 
         public function __construct($params) {
             if(isset($params['url'])){
@@ -36,6 +37,9 @@ use Exception;
                 date_default_timezone_set("America/Mexico_City");
                 self::$_expirationDate = new \DateTime('NOW');
                 self::$_expirationDate->add(new \DateInterval(self::$_timeSession));
+            }
+            if(isset($params['_timeOut'])){
+                self::$_timeOut = $params['_timeOut'];
             }
         }
         
@@ -75,7 +79,9 @@ use Exception;
         public static function get_proxy(){
             return self::$_proxy;
         }
-        
+        public static function get_timeout(){
+            return self::$_timeOut;
+        }
         
     };
 

--- a/SWServices/Stamp/StampRequest.php
+++ b/SWServices/Stamp/StampRequest.php
@@ -3,7 +3,7 @@
 namespace SWServices\Stamp;
 use Exception;
 class StampRequest{
-    public static function sendReq($url, $token, $xml, $version, $proxy){
+    public static function sendReq($url, $token, $xml, $version, $proxy, $timeout=60){
         $delimiter = '-------------' . uniqid();
         $fileFields = array(
             'xml' => array(
@@ -32,6 +32,12 @@ class StampRequest{
         $curl  = curl_init($url.'/cfdi33/stamp/'.$version);
         curl_setopt($curl , CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl , CURLOPT_POST, true);
+        
+        // TIMEOUT
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0); // seconds
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout); // seconds
+        // END TIMEOUT
+        
         if(isset($proxy)){
             curl_setopt($curl , CURLOPT_PROXY, $proxy);
         }
@@ -56,7 +62,7 @@ class StampRequest{
     }
 
 
-    public static function sendReqB64($url, $token, $xml, $version){
+    public static function sendReqB64($url, $token, $xml, $version, $timeout=60){
         $delimiter = '-------------' . uniqid();
         $fileFields = array(
             'xml' => array(
@@ -85,6 +91,12 @@ class StampRequest{
         $curl  = curl_init($url.'/cfdi33/stamp/'.$version.'/b64');
         curl_setopt($curl , CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl , CURLOPT_POST, true);
+
+        // TIMEOUT
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0); // seconds
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout); // seconds
+        // END TIMEOUT
+
         curl_setopt($curl , CURLOPT_HTTPHEADER , array(
             'Content-Type: multipart/form-data; boundary=' . $delimiter,
             'Content-Length: ' . strlen($data),

--- a/SWServices/Stamp/StampService.php
+++ b/SWServices/Stamp/StampService.php
@@ -16,26 +16,26 @@ class StampService extends Services{
         return new StampService($params);
     }
     public static function StampV1($xml){
-        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1",Services::get_proxy());
+        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v1",Services::get_proxy(),Services::get_default_timeout());
     }
      public static function StampV2($xml, $isb64 = false){
          if($isb64){
-            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v2",Services::get_proxy());
+            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v2",Services::get_proxy(),Services::get_default_timeout());
          }
-        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2",Services::get_proxy());
+        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v2",Services::get_proxy(),Services::get_default_timeout());
     }
 
      public static function StampV3($xml, $isb64 = false){
          if($isb64){
-            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v3",Services::get_proxy());
+            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v3",Services::get_proxy(),Services::get_default_timeout());
          }
-        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3",Services::get_proxy());
+        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v3",Services::get_proxy(),Services::get_default_timeout());
     }
      public static function StampV4($xml, $isb64 = false){
          if($isb64){
-            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v4",Services::get_proxy());
+            return stampRequest::sendReqB64(Services::get_url(), Services::get_token(), $xml, "v4",Services::get_proxy(),Services::get_default_timeout());
          }
-        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4",Services::get_proxy());
+        return stampRequest::sendReq(Services::get_url(), Services::get_token(), $xml, "v4",Services::get_proxy(),Services::get_default_timeout());
     }
 }
 


### PR DESCRIPTION
Agregar timeout para evitar que un comprobante sea timbrado pero que no se reciba respuesta por un timeout.