### PR TITLE
Agregar content type

### DIFF
--- a/SWServices/JSonIssuer/JsonIssuerRequest.php
+++ b/SWServices/JSonIssuer/JsonIssuerRequest.php
@@ -6,6 +6,7 @@ use Exception;
 
 class JsonIssuerRequest{
    
+header('Content-Type: text/plain');
     
   public static function sendReq($url, $token, $json, $version, $isB64, $proxy){
     $curl = curl_init();


### PR DESCRIPTION
El servicio no regresa en texto el cfdi, se agrega un content type para que el navegador pueda leer todo el response.