### PR TITLE
Error en PHP Unit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         }
     },
     "require": {
-        "phpunit/phpunit": "^5",
+        "phpunit/phpunit": "~8.5.0",
         "doctrine/instantiator" : "^1.0.2"
     }
 }


### PR DESCRIPTION
Esa librería tiene un error en el PHP Unit, la mayoría de frameworks ya están por la versión 8 o superior, incluso el composer manda el error