### PR TITLE
PHP Unit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         }
     ],
     "require-dev": {
+         "phpunit/phpunit": "~8.5.0"
     },
    "autoload": {
     "psr-4": {
@@ -40,8 +41,7 @@
             "tests\\": "tests/"
         }
     },
-    "require": {
-        "phpunit/phpunit": "^5",
+    "require": {       
         "doctrine/instantiator" : "^1.0.2"
     }
 }


### PR DESCRIPTION
Error en los require, la de PHP Unit no debería ir en requerimientos para funcionar, debería ir en DEV y tiene que ser versión superior para no causar conflictos con frameworks actuales