### PR TITLE
#58 se eliminan require_once innecesarios.

### DIFF
--- a/SWServices/Helpers/RequestHelper.php
+++ b/SWServices/Helpers/RequestHelper.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace SWServices\Helpers;
-require_once 'SWServices/Helpers/ResponseHelper.php';
 
 use Exception;
 

--- a/SWServices/Resend/ResendService.php
+++ b/SWServices/Resend/ResendService.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace SWServices\Resend;
-require_once 'SWServices/Resend/ResendRequest.php';
 
 class ResendService extends ResendRequest {
     public function __construct($params)

--- a/SWServices/Services.php
+++ b/SWServices/Services.php
@@ -1,6 +1,5 @@
 <?php
 namespace SWServices;
-require_once 'SWServices/Helpers/RequestHelper.php';
 use SWServices\Authentication\AuthenticationService as Authentication;
 use SWServices\Helpers\RequestHelper as Request;
 use Exception;


### PR DESCRIPTION
Corrección de defecto #58 en php ^7.4